### PR TITLE
switch to shared concurrency

### DIFF
--- a/lib/logstash/outputs/stackdriver_logging.rb
+++ b/lib/logstash/outputs/stackdriver_logging.rb
@@ -82,7 +82,7 @@ class LogStash::Outputs::StackdriverLogging < LogStash::Outputs::Base
   # Array of field names to remove from the event immediately prior to sending.
   config :strip_fields, :validate => :array, :required => false, :default => []
 
-  concurrency :single
+  concurrency :shared
 
   public
   def register


### PR DESCRIPTION
I have run into a throughput problem with the `:single` concurrency and after a quick read through it seems that using `:shared` is thread safe as everything in `multi_receive` creates new memory and I believe the Ruby google api client is already thread safe.  

Any objection to making this `:shared`?